### PR TITLE
#4 clean up #preloadImages from unused code

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -52,12 +52,6 @@ export default {
     },
 
     preloadImages() {
-
-      this.images.forEach(element => {
-        const img = new Image()
-        img.src = element
-      })
-
       this.imagesAreReady = true
     },
 


### PR DESCRIPTION
clean up: remove unused forEach, since it do nothing.

forEach just iterates by each element of array and that's all
for each element callback is called

in your callback  you just create new image block and set to its src you image-src(element) and do not use it further (`img` value is not used anywhere). That means do nothing.